### PR TITLE
Fix tests, deprecate XPATH and use CSS selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.0.0
+## 0.0.1
 
-- Initial version, created by Stagehand
+- Initial Version. Support html parsing, Node management, and Node Tree Diffing.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Essence is a super-simple Virtual DOM implementation in Dart.
 Essence can parse DOM-Strings into Essence Nodes.
 
 Essence can diff Essence Nodes and provide a list of actions on how to go from NodeList A to NodeList B.
+
 ## Usage
 
 A simple usage example:
@@ -20,7 +21,40 @@ main() {
   var tree2 = TreeParser.parse("<b></b>");
   TreeDiff.diff(tree1, tree2).forEach((action) => {
     print(action.node);
-    print(action.XPATH);
+    print(action.selector);
+  });
+}
+```
+
+More interesting perhaps, you can leverage those actions to make updates to an actual DOM. It's worth mentioning that these CSS selectors are unbounded by default. You can pass in a `currentSelector` to `TreeDiff`'s `diff` function to scope them.
+
+```html
+<h1 class="root">
+  <span>Text!</span>
+</h1>
+```
+
+```dart
+import 'dart:html';
+import 'package:essence/essence.dart';
+
+main() {
+  var element = Element.div();
+  element.className = 'root';
+  element.childNodes.add(Element.span());
+
+  var element2 = Element.div();
+  element.className = 'root';
+  element2.childNodes.add(Element.article());
+
+  var eleParsed = TreeParser.parseElement(element);
+  var ele2Parsed = TreeParser.parseElement(element2);
+  var actions =
+      TreeDiff.diff(eleParsed, ele2Parsed, currentSelector: '.root');
+  actions.forEach((action) {
+    // ideally, do the action instead of just printing it, but Ill leave the code for that up to you :)
+    print(
+        '${action is NodeDeletion ? "Delete" : "Insert"} ${action.node.type} at selector ${action.selector}');
   });
 }
 ```

--- a/lib/src/tree_diff.dart
+++ b/lib/src/tree_diff.dart
@@ -2,33 +2,33 @@ import 'package:essence/src/node.dart';
 
 /// Define actions to be processed against a tree.
 class NodeAction {
-  String XPATH;
+  String selector;
   Node node;
 }
 
 class NodeInsertion implements NodeAction {
   @override
-  String XPATH;
+  String selector;
   @override
   Node node;
 
-  NodeInsertion({this.node, this.XPATH});
+  NodeInsertion({this.node, this.selector});
 }
 
 class NodeDeletion implements NodeAction {
   @override
-  String XPATH;
+  String selector;
   @override
   Node node;
 
-  NodeDeletion({this.node, this.XPATH});
+  NodeDeletion({this.node, this.selector});
 }
 
 class TreeDiff {
   /// Diff two node lists, returning a list of NodeActions
   static List<NodeAction> diff(
       List<Node> baseNodeList, List<Node> targetNodeList,
-      {currentXPATH = ''}) {
+      {currentSelector = ''}) {
     // ignore: omit_local_variable_types
     List<NodeAction> actions = [];
     if (baseNodeList.isEmpty && targetNodeList.isEmpty) {
@@ -42,7 +42,7 @@ class TreeDiff {
 
     if (targetEntries.isEmpty) {
       actions.addAll(baseEntries.entries.map((e) => NodeDeletion(
-          node: e.value, XPATH: '${currentXPATH}/*[${e.key + 1}]')));
+          node: e.value, selector: _createSelector(currentSelector, e.key))));
     }
 
     var matchingIndexes = targetEntriesList
@@ -52,20 +52,25 @@ class TreeDiff {
     var nonMatchingIndexesForBase = baseEntriesList
         .where((entry) => entry.value != targetEntries[entry.key]);
 
-    actions.addAll(nonMatchingIndexesForBase.map((e) =>
-        NodeDeletion(node: e.value, XPATH: '${currentXPATH}/*[${e.key + 1}]')));
+    actions.addAll(nonMatchingIndexesForBase.map((e) => NodeDeletion(
+        node: e.value, selector: _createSelector(currentSelector, e.key))));
     actions.addAll(nonMatchingIndexesForTarget.map((e) => NodeInsertion(
-        node: e.value, XPATH: '${currentXPATH}/*[${e.key + 1}]')));
+        node: e.value, selector: _createSelector(currentSelector, e.key))));
 
     // process child nodes of matching
     if (matchingIndexes.isNotEmpty) {
       actions.addAll(matchingIndexes
           .map((e) => TreeDiff.diff(
               baseEntries[e.key].children ?? [], e.value.children ?? [],
-              currentXPATH: '${currentXPATH}/*[${e.key + 1}]'))
+              currentSelector: _createSelector(currentSelector, e.key)))
           .expand((e) => e));
     }
 
     return actions;
+  }
+
+  static String _createSelector(currentSelector, index) {
+    return '${currentSelector != "" ? currentSelector + " >" : ""} *:nth-of-type(${index})'
+        .trim();
   }
 }

--- a/lib/src/tree_parser.dart
+++ b/lib/src/tree_parser.dart
@@ -1,20 +1,26 @@
 import 'package:html/parser.dart' as parser;
 import 'package:html/dom.dart' as dom;
+import 'package:universal_html/html.dart' as uhtml;
 
 import 'package:essence/src/node.dart';
 
 class TreeParser {
   static List<Node> parse(String text) {
     var document = parser.parseFragment(text);
-    return TreeParser.convertNodes(document.children);
+    return TreeParser._convertNodes(document.children);
   }
 
-  static List<Node> convertNodes(List<dom.Element> elements) {
+  static List<Node> parseElement(uhtml.Element element) {
+    var document = parser.parseFragment(element.outerHtml);
+    return TreeParser._convertNodes(document.children);
+  }
+
+  static List<Node> _convertNodes(List<dom.Element> elements) {
     var nodes = elements.map((element) {
       return Node(
           type: element.localName,
           properties: element.attributes,
-          children: convertNodes(element.children));
+          children: _convertNodes(element.children));
     }).toList();
 
     return nodes;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,15 @@
 name: essence
 description: A starting point for Dart libraries or applications.
-# version: 1.0.0
+version: 0.0.1
+repository: https://www.github.com/bradcypert/essence
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: ">=2.8.1 <3.0.0"
 
 dependencies:
-#  path: ^1.7.0
   html: ^0.14.0+3
+  universal_html: ^1.2.1
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/test/html_test.dart
+++ b/test/html_test.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import 'package:essence/essence.dart';
+import 'package:universal_html/html.dart';
+
+void main() {
+  group('HTML Test', () {
+    test('works with dart:html', () {
+      var element = Element.div();
+      element.className = 'root';
+      element.childNodes.add(Element.span());
+
+      var element2 = Element.div();
+      element.className = 'root';
+      element2.childNodes.add(Element.article());
+
+      var eleParsed = TreeParser.parseElement(element);
+      var ele2Parsed = TreeParser.parseElement(element2);
+      var actions =
+          TreeDiff.diff(eleParsed, ele2Parsed, currentSelector: '.root');
+      actions.forEach((action) {
+        print(
+            '${action is NodeDeletion ? "Delete" : "Insert"} ${action.node.type} at selector ${action.selector}');
+      });
+    });
+  });
+}

--- a/test/tree_diff_test.dart
+++ b/test/tree_diff_test.dart
@@ -12,7 +12,7 @@ void main() {
       var node = Node(type: 'a');
       var actions = TreeDiff.diff([], [node]);
       expect(actions[0].node, equals(node));
-      expect(actions[0].XPATH, equals('/*[1]'));
+      expect(actions[0].selector, equals('*:nth-of-type(0)'));
       expect(actions[0] is NodeInsertion, equals(true));
     });
 
@@ -22,7 +22,7 @@ void main() {
       var node = Node(type: 'a');
       var actions = TreeDiff.diff([node], []);
       expect(actions[0].node, equals(node));
-      expect(actions[0].XPATH, equals('/*[1]'));
+      expect(actions[0].selector, equals('*:nth-of-type(0)'));
       expect(actions[0] is NodeDeletion, equals(true));
     });
 
@@ -33,7 +33,7 @@ void main() {
       var node2 = Node(type: 'b');
       var actions = TreeDiff.diff([node2, node], [node]);
       expect(actions[0].node, equals(node2));
-      expect(actions[0].XPATH, equals('/*[1]'));
+      expect(actions[0].selector, equals('*:nth-of-type(0)'));
       expect(actions[0] is NodeDeletion, equals(true));
     });
 
@@ -43,7 +43,7 @@ void main() {
       var actions = TreeDiff.diff([node, node2], [node]);
       expect(actions.length, equals(1));
       expect(actions[0].node, equals(node2));
-      expect(actions[0].XPATH, equals('/*[2]'));
+      expect(actions[0].selector, equals('*:nth-of-type(1)'));
       expect(actions[0] is NodeDeletion, equals(true));
     });
 
@@ -54,10 +54,10 @@ void main() {
       var node2 = Node(type: 'b');
       var actions = TreeDiff.diff([node1], [node2]);
       expect(actions[0].node, equals(node1));
-      expect(actions[0].XPATH, equals('/*[1]'));
+      expect(actions[0].selector, equals('*:nth-of-type(0)'));
       expect(actions[0] is NodeDeletion, equals(true));
       expect(actions[1].node, equals(node2));
-      expect(actions[1].XPATH, equals('/*[1]'));
+      expect(actions[1].selector, equals('*:nth-of-type(0)'));
       expect(actions[1] is NodeInsertion, equals(true));
     });
 
@@ -81,16 +81,20 @@ void main() {
       var actions = TreeDiff.diff([node2, node1], [node1, node2]);
       expect(actions.length, equals(4));
       expect(actions[0].node, equals(node2.children[0]));
-      expect(actions[0].XPATH, equals('/*[1]/*[1]'));
+      expect(
+          actions[0].selector, equals('*:nth-of-type(0) > *:nth-of-type(0)'));
       expect(actions[0] is NodeDeletion, equals(true));
       expect(actions[1].node, equals(node1.children[0]));
-      expect(actions[1].XPATH, equals('/*[1]/*[1]'));
+      expect(
+          actions[1].selector, equals('*:nth-of-type(0) > *:nth-of-type(0)'));
       expect(actions[1] is NodeInsertion, equals(true));
       expect(actions[2].node, equals(node1.children[0]));
-      expect(actions[2].XPATH, equals('/*[2]/*[1]'));
+      expect(
+          actions[2].selector, equals('*:nth-of-type(1) > *:nth-of-type(0)'));
       expect(actions[2] is NodeDeletion, equals(true));
       expect(actions[3].node, equals(node2.children[0]));
-      expect(actions[3].XPATH, equals('/*[2]/*[1]'));
+      expect(
+          actions[3].selector, equals('*:nth-of-type(1) > *:nth-of-type(0)'));
       expect(actions[3] is NodeInsertion, equals(true));
     });
 


### PR DESCRIPTION
Change XPATH selectors to CSS Selectors (Apparently XPATH is deprecated)
Add better examples and get ready for initial pub.dev publish.

Add support for working with dart2js nodes directly.